### PR TITLE
create dca language for missing labels in tl_settings

### DIFF
--- a/src/Resources/contao/languages/de/tl_settings.php
+++ b/src/Resources/contao/languages/de/tl_settings.php
@@ -1,0 +1,14 @@
+<?php if (!defined('TL_ROOT')) die('You cannot access this file directly!');
+
+
+/**
+ * Legends
+ */
+$GLOBALS['TL_LANG']['tl_settings']['login_link_legend'] = 'Login-Link Einstellungen';
+
+
+/**
+ * Fields
+ */
+$GLOBALS['TL_LANG']['tl_settings']['login_link_autoKey'] 	= 'Login-Link Auto-Key';
+$GLOBALS['TL_LANG']['tl_settings']['login_link_defaultKeyLength'] 	= 'Login-Link standart Key-Länge';


### PR DESCRIPTION
Create missing tl_settings.php for this dca array:
https://github.com/thescrat/contao-loginlink/blob/02621f6d80c50ef3390958419bb86a318bcf23c6/src/Resources/contao/dca/tl_settings.php#L25-L38