### PR TITLE
Update bundle to work in contao version 4.13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,17 +14,9 @@
         "forum": "https://community.contao.org"
     },
     "require": {
-        "php": "^7.1",
-        "contao/core-bundle": "^4.5",
-        "doctrine/dbal": "^2.7",
-        "psr/log": "^1.0",
-        "symfony/config": "^3.3 || ^4.0",
-        "symfony/dependency-injection": "^3.3 || ^4.0",
-        "symfony/event-dispatcher": "^3.3 || ^4.0",
-        "symfony/http-foundation": "^3.3 || ^4.0",
-        "symfony/http-kernel": "^3.3 || ^4.0",
-        "symfony/security-core": "^3.3 || ^4.0",
-        "symfony/security-http": "^3.3 || ^4.0"
+        "php": "^7.4 | ^8.0",
+        "contao/core-bundle": "^4.13",
+        "psr/log": "^1.0"
     },
     "require-dev": {
         "contao/manager-plugin": "~2.0",
@@ -36,10 +28,10 @@
     },
     "autoload": {
         "psr-4": {
-            "thescrat\\LoginLinkBundle\\": "src/"
+            "Thescrat\\LoginLinkBundle\\": "src/"
         }
     },
     "extra": {
-        "contao-manager-plugin": "thescrat\\LoginLinkBundle\\ContaoManager\\Plugin"
+        "contao-manager-plugin": "Thescrat\\LoginLinkBundle\\ContaoManager\\Plugin"
     }
 }

--- a/src/ContaoManager/Plugin.php
+++ b/src/ContaoManager/Plugin.php
@@ -9,13 +9,13 @@
  * @link       http://github.com/thescrat/contao-loginlink
  */
 
-namespace thescrat\LoginLinkBundle\ContaoManager;
+namespace Thescrat\LoginLinkBundle\ContaoManager;
 
 use Contao\CoreBundle\ContaoCoreBundle;
 use Contao\ManagerPlugin\Bundle\BundlePluginInterface;
 use Contao\ManagerPlugin\Bundle\Config\BundleConfig;
 use Contao\ManagerPlugin\Bundle\Parser\ParserInterface;
-use thescrat\LoginLinkBundle\thescratLoginLinkBundle;
+use Thescrat\LoginLinkBundle\ThescratLoginLinkBundle;
 
 class Plugin implements BundlePluginInterface
 {
@@ -25,7 +25,7 @@ class Plugin implements BundlePluginInterface
     public function getBundles(ParserInterface $parser): array
     {
         return [
-            BundleConfig::create(thescratLoginLinkBundle::class)
+            BundleConfig::create(ThescratLoginLinkBundle::class)
                 ->setLoadAfter([ContaoCoreBundle::class])
                 ->setReplace(['loginlink']),
         ];

--- a/src/DependencyInjection/ThescratLoginLinkExtension.php
+++ b/src/DependencyInjection/ThescratLoginLinkExtension.php
@@ -9,14 +9,14 @@
  * @link       http://github.com/thescrat/contao-loginlink
  */
 
-namespace thescrat\LoginLinkBundle\DependencyInjection;
+namespace Thescrat\LoginLinkBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 
-class thescratLoginLinkExtension extends Extension
+class ThescratLoginLinkExtension extends Extension
 {
     /**
      * {@inheritdoc}

--- a/src/Resources/config/listeners.yml
+++ b/src/Resources/config/listeners.yml
@@ -1,6 +1,6 @@
 services:
     thescrat.loginlink.listener.generatepage:
-        class: thescrat\LoginLinkBundle\EventListener\GeneratePageListener
+        class: Thescrat\LoginLinkBundle\EventListener\GeneratePageListener
         arguments:
             - '@contao.security.frontend_user_provider'
             - '@security.token_storage'

--- a/src/ThescratLoginLinkBundle.php
+++ b/src/ThescratLoginLinkBundle.php
@@ -9,10 +9,10 @@
  * @link       http://github.com/thescrat/contao-loginlink
  */
 
-namespace thescrat\LoginLinkBundle;
+namespace Thescrat\LoginLinkBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-class thescratLoginLinkBundle extends Bundle
+class ThescratLoginLinkBundle extends Bundle
 {
 }


### PR DESCRIPTION
Hallo, ich habe mir mal die Codebasis angesehen und ein paar Veränderung eingepflegt und diese lokal in meiner frischen Contao 4.13 Version getestet.

Ein paar Anmerkungen:
### composers.json
Hier habe ich die meisten requires herausgenommen, da diese schon von anderen Core-Elementen von Contao required werden.
Bedeutet, da dein Bundle explizit als Contao Bundle deklariert ist, sind diese Abhängigkeiten immer vorhanden.
Du kannst diese aber auch, wenn gewünscht, manuell erneut requiren und eben auf die verwendete Version von Contao referenzieren.

### Namespaces
Ich habe die Namespaces der gängigen Namespace Konvention angepasst.
Hierfür musste ich nur den Vendor vom Paket groß schreiben, also statt **thescrat** -> **Thescrat**

### loadUserByIdentifier
Die Methode loadUserByUsername und die zugehörige Exception ist mittlerweile deprecated.
Ich habe diese durch **loadUserByIdentifier** ersetzt.

##

Wenn Du das Bundle später noch weiter verbessern möchtest, würde ich dir nochmal die Contao Dokumentation empfehlen.
Dort kannst Du beispielsweise deinen save_callback aus den dca-Files herausnehmen, denn dort hat der eigentlich nichts mehr zu suchen.
Oder auch statt array_insert mal den PalettenManipulator von Contao verwenden.
